### PR TITLE
Fix for failing pending actions.

### DIFF
--- a/src/cointipbot.py
+++ b/src/cointipbot.py
@@ -244,7 +244,7 @@ class CointipBot(object):
                     if self.conf.reddit.messages.sorry and not m.subject in ['post reply', 'comment reply']:
                         user = ctb_user.CtbUser(name=m.author.name, redditobj=m.author, ctb=self)
                         tpl = self.jenv.get_template('didnt-understand.tpl')
-                        msg = tpl.render(user_from=user.name, what='comment' if m.was_comment else 'message', source_link=m.permalink if hasattr(m, 'permalink') else None, ctb=self)
+                        msg = tpl.render(user_from=user.name, what='comment' if m.was_comment else 'message', source_link=ctb_misc.permalink(m.msg), ctb=self)
                         lg.debug("CointipBot::check_inbox(): %s", msg)
                         user.tell(subj='What?', msg=msg, msgobj=m if not m.was_comment else None)
 

--- a/src/ctb/ctb_misc.py
+++ b/src/ctb/ctb_misc.py
@@ -53,6 +53,12 @@ def praw_call(prawFunc, *extraArgs, **extraKwArgs):
 
     return True
 
+def permalink(message):
+    """
+    Return permalink if possible for message.
+    """
+    return getattr(message, '_fast_permalink', None)
+
 def reddit_get_parent_author(comment, reddit, ctb):
     """
     Return author of comment's parent comment


### PR DESCRIPTION
A bug currently exists where actions that are pending do not properly have `msg_link` set. As a result attempting to `accept` or `decline` will not work as expected.

This PR _should_ resolve that issue. However, I do not actually have an instance of the bot running, and thus am unable to verify. It would be ideal if tipnyan tried out this branch prior to merging.